### PR TITLE
Fix: the calculation of correct Wattage for CPU and GPU only

### DIFF
--- a/pc_builder/app/models/build.rb
+++ b/pc_builder/app/models/build.rb
@@ -19,8 +19,9 @@ class Build < ApplicationRecord
   end
 
   def total_wattage
-    wattage = parts.sum(&:wattage) || 0
-    Rails.logger.debug "[BUILD #{id}] Calculated total wattage: #{wattage}W"
+    # MODIFIED: Filter parts to only include 'Cpu' and 'Gpu' types before summing.
+    wattage = parts.where(type: ['Cpu', 'Gpu']).sum(&:wattage) || 0
+    Rails.logger.debug "[BUILD #{id}] Calculated total wattage (CPU + GPU only): #{wattage}W"
     wattage
   end
 

--- a/pc_builder/coverage/.resultset.json
+++ b/pc_builder/coverage/.resultset.json
@@ -1,105 +1,105 @@
 {
   "RSpec": {
     "coverage": {
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/application_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/application_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/build_items_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/build_items_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/builds_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/builds_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/coolers_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/coolers_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/cpus_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/cpus_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/gpus_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/gpus_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/home_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/home_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/memories_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/memories_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/motherboards_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/motherboards_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/parts_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/parts_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/pc_cases_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/pc_cases_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/psus_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/psus_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/storages_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/storages_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/helpers/users_helper.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/helpers/users_helper.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/jobs/application_job.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/jobs/application_job.rb": {
         "lines": [
           1,
           null,
@@ -111,7 +111,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/lib/database_logger.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/lib/database_logger.rb": {
         "lines": [
           null,
           null,
@@ -241,7 +241,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/lib/logging_helpers.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/lib/logging_helpers.rb": {
         "lines": [
           null,
           null,
@@ -449,7 +449,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/mailers/application_mailer.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/mailers/application_mailer.rb": {
         "lines": [
           1,
           1,
@@ -458,7 +458,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/build_item.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/build_item.rb": {
         "lines": [
           1,
           1,
@@ -487,11 +487,11 @@
           1,
           null,
           1,
-          69,
+          68,
           null,
           null,
           1,
-          69,
+          68,
           null,
           null,
           1,
@@ -499,10 +499,10 @@
           null,
           null,
           1,
-          83,
+          82,
           6,
           null,
-          77,
+          76,
           null,
           null,
           null,
@@ -515,16 +515,16 @@
         ],
         "branches": {
           "[:\"&.\", 0, 28, 58, 28, 68]": {
-            "[:then, 1, 28, 58, 28, 68]": 69,
+            "[:then, 1, 28, 58, 28, 68]": 68,
             "[:else, 2, 28, 58, 28, 68]": 0
           },
           "[:\"&.\", 3, 28, 100, 28, 111]": {
-            "[:then, 4, 28, 100, 28, 111]": 69,
+            "[:then, 4, 28, 100, 28, 111]": 68,
             "[:else, 5, 28, 100, 28, 111]": 0
           },
           "[:if, 6, 40, 4, 44, 7]": {
             "[:then, 7, 41, 6, 41, 117]": 6,
-            "[:else, 8, 43, 6, 43, 82]": 77
+            "[:else, 8, 43, 6, 43, 82]": 76
           },
           "[:if, 9, 48, 4, 50, 7]": {
             "[:then, 10, 49, 6, 49, 131]": 5,
@@ -532,7 +532,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/application_record.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/application_record.rb": {
         "lines": [
           1,
           1,
@@ -540,7 +540,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/build.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/build.rb": {
         "lines": [
           1,
           1,
@@ -563,9 +563,10 @@
           null,
           null,
           1,
-          11,
-          11,
-          11,
+          null,
+          10,
+          10,
+          10,
           null,
           null,
           1,
@@ -623,11 +624,11 @@
           1,
           null,
           1,
-          125,
+          124,
           null,
           null,
           1,
-          125,
+          124,
           null,
           null,
           1,
@@ -635,51 +636,50 @@
           null,
           null,
           1,
-          146,
+          144,
           6,
           null,
-          140,
+          138,
           null,
           null,
           null,
           1,
-          12,
           11,
-          null,
+          10,
           null,
           null
         ],
         "branches": {
-          "[:\"&.\", 0, 50, 17, 50, 27]": {
-            "[:then, 1, 50, 17, 50, 27]": 3,
-            "[:else, 2, 50, 17, 50, 27]": 0
+          "[:\"&.\", 0, 51, 17, 51, 27]": {
+            "[:then, 1, 51, 17, 51, 27]": 3,
+            "[:else, 2, 51, 17, 51, 27]": 0
           },
-          "[:unless, 3, 67, 4, 67, 29]": {
-            "[:else, 4, 67, 4, 67, 29]": 1,
-            "[:then, 5, 67, 4, 67, 14]": 1
+          "[:unless, 3, 68, 4, 68, 29]": {
+            "[:else, 4, 68, 4, 68, 29]": 1,
+            "[:then, 5, 68, 4, 68, 14]": 1
           },
-          "[:unless, 6, 72, 4, 72, 41]": {
-            "[:else, 7, 72, 4, 72, 41]": 2,
-            "[:then, 8, 72, 4, 72, 13]": 1
+          "[:unless, 6, 73, 4, 73, 41]": {
+            "[:else, 7, 73, 4, 73, 41]": 2,
+            "[:then, 8, 73, 4, 73, 13]": 1
           },
-          "[:if, 9, 94, 4, 98, 7]": {
-            "[:then, 10, 95, 6, 95, 118]": 6,
-            "[:else, 11, 97, 6, 97, 83]": 140
+          "[:if, 9, 95, 4, 99, 7]": {
+            "[:then, 10, 96, 6, 96, 118]": 6,
+            "[:else, 11, 98, 6, 98, 83]": 138
           },
-          "[:if, 12, 102, 4, 104, 7]": {
-            "[:then, 13, 103, 6, 103, 122]": 11,
-            "[:else, 14, 102, 4, 104, 7]": 1
+          "[:if, 12, 103, 4, 105, 7]": {
+            "[:then, 13, 104, 6, 104, 122]": 10,
+            "[:else, 14, 103, 4, 105, 7]": 1
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/cooler.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/cooler.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/part.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/part.rb": {
         "lines": [
           1,
           1,
@@ -711,10 +711,10 @@
           null,
           null,
           1,
-          333,
-          329,
-          329,
-          329,
+          332,
+          328,
+          328,
+          328,
           null,
           null,
           1,
@@ -725,19 +725,19 @@
           null,
           1,
           1,
-          329,
+          328,
           null,
           1,
-          329,
+          328,
           null,
           1,
           1,
           null,
           1,
-          350,
+          349,
           15,
           null,
-          335,
+          334,
           null,
           null,
           1,
@@ -755,12 +755,12 @@
             "[:else, 5, 21, 4, 21, 80]": 1
           },
           "[:unless, 6, 31, 4, 31, 31]": {
-            "[:else, 7, 31, 4, 31, 31]": 329,
+            "[:else, 7, 31, 4, 31, 31]": 328,
             "[:then, 8, 31, 4, 31, 12]": 4
           },
           "[:if, 9, 54, 4, 58, 7]": {
             "[:then, 10, 55, 6, 55, 128]": 15,
-            "[:else, 11, 57, 6, 57, 93]": 335
+            "[:else, 11, 57, 6, 57, 93]": 334
           },
           "[:if, 12, 61, 4, 61, 143]": {
             "[:then, 13, 61, 4, 61, 121]": 1,
@@ -768,7 +768,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/cpu.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/cpu.rb": {
         "lines": [
           1,
           null,
@@ -787,11 +787,11 @@
           1,
           null,
           1,
-          144,
+          143,
           8,
           null,
-          136,
-          136,
+          135,
+          135,
           null,
           null,
           null
@@ -799,36 +799,36 @@
         "branches": {
           "[:if, 0, 18, 4, 23, 7]": {
             "[:then, 1, 19, 6, 19, 121]": 8,
-            "[:else, 2, 21, 6, 22, 168]": 136
+            "[:else, 2, 21, 6, 22, 168]": 135
           },
           "[:if, 3, 22, 6, 22, 168]": {
-            "[:then, 4, 22, 6, 22, 140]": 64,
+            "[:then, 4, 22, 6, 22, 140]": 63,
             "[:else, 5, 22, 6, 22, 168]": 72
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/gpu.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/gpu.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/memory.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/memory.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/motherboard.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/motherboard.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/pc_case.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/pc_case.rb": {
         "lines": [
           1,
           null,
@@ -838,21 +838,21 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/psu.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/psu.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/storage.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/storage.rb": {
         "lines": [
           1,
           null
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/models/user.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/models/user.rb": {
         "lines": [
           1,
           null,
@@ -868,7 +868,7 @@
           1,
           null,
           null,
-          144,
+          143,
           null,
           1,
           null,
@@ -896,17 +896,17 @@
           1,
           null,
           1,
-          143,
-          143,
-          143,
+          142,
+          142,
+          142,
           null,
           null,
           1,
-          131,
+          130,
           null,
           null,
           1,
-          131,
+          130,
           null,
           null,
           1,
@@ -914,10 +914,10 @@
           null,
           null,
           1,
-          143,
+          142,
           10,
           null,
-          133,
+          132,
           null,
           null,
           null
@@ -925,15 +925,15 @@
         "branches": {
           "[:if, 0, 45, 4, 45, 111]": {
             "[:then, 1, 45, 4, 45, 89]": 2,
-            "[:else, 2, 45, 4, 45, 111]": 141
+            "[:else, 2, 45, 4, 45, 111]": 140
           },
           "[:if, 3, 61, 4, 65, 7]": {
             "[:then, 4, 62, 6, 62, 127]": 10,
-            "[:else, 5, 64, 6, 64, 92]": 133
+            "[:else, 5, 64, 6, 64, 92]": 132
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/application_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/application_controller.rb": {
         "lines": [
           1,
           null,
@@ -1117,7 +1117,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/build_items_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/build_items_controller.rb": {
         "lines": [
           1,
           1,
@@ -1144,16 +1144,35 @@
           null,
           12,
           null,
+          null,
+          null,
+          null,
+          1,
+          0,
+          0,
+          0,
+          null,
+          0,
+          0,
+          null,
+          0,
+          null,
+          null,
+          0,
           null
         ],
         "branches": {
           "[:if, 0, 10, 4, 17, 7]": {
             "[:then, 1, 11, 6, 13, 74]": 4,
             "[:else, 2, 15, 6, 16, 76]": 8
+          },
+          "[:if, 3, 34, 4, 38, 7]": {
+            "[:then, 4, 35, 6, 35, 79]": 0,
+            "[:else, 5, 37, 6, 37, 54]": 0
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/sessions_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/sessions_controller.rb": {
         "lines": [
           1,
           null,
@@ -1231,7 +1250,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/builds_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/builds_controller.rb": {
         "lines": [
           1,
           null,
@@ -1545,7 +1564,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/parts_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/parts_controller.rb": {
         "lines": [
           1,
           null,
@@ -1694,7 +1713,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/users_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/users_controller.rb": {
         "lines": [
           1,
           null,
@@ -1788,7 +1807,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/coolers_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/coolers_controller.rb": {
         "lines": [
           1,
           1,
@@ -1804,7 +1823,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/cpus_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/cpus_controller.rb": {
         "lines": [
           1,
           1,
@@ -1820,7 +1839,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/gpus_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/gpus_controller.rb": {
         "lines": [
           1,
           1,
@@ -1836,7 +1855,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/home_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/home_controller.rb": {
         "lines": [
           1,
           null,
@@ -1912,7 +1931,7 @@
           }
         }
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/memories_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/memories_controller.rb": {
         "lines": [
           1,
           1,
@@ -1928,7 +1947,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/motherboards_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/motherboards_controller.rb": {
         "lines": [
           1,
           1,
@@ -1944,7 +1963,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/pc_cases_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/pc_cases_controller.rb": {
         "lines": [
           1,
           1,
@@ -1960,7 +1979,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/psus_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/psus_controller.rb": {
         "lines": [
           1,
           1,
@@ -1975,7 +1994,7 @@
         ],
         "branches": {}
       },
-      "/Users/harshwadhawe/Code/Fall 25/SE/Project 1/Project-1-SE/pc_builder/app/controllers/storages_controller.rb": {
+      "/mnt/c/Users/IVC-LAB-7/study/course/software/PJ1/Project-1-SE/pc_builder/app/controllers/storages_controller.rb": {
         "lines": [
           1,
           1,
@@ -1992,7 +2011,7 @@
         "branches": {}
       }
     },
-    "timestamp": 1759783038
+    "timestamp": 1759803805
   },
   "Cucumber Features": {
     "coverage": {

--- a/pc_builder/coverage/.resultset.json
+++ b/pc_builder/coverage/.resultset.json
@@ -2011,7 +2011,7 @@
         "branches": {}
       }
     },
-    "timestamp": 1759803805
+    "timestamp": 1759804447
   },
   "Cucumber Features": {
     "coverage": {

--- a/pc_builder/coverage/index.html
+++ b/pc_builder/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-10-06T21:23:25-05:00">2025-10-06T21:23:25-05:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-10-06T21:34:08-05:00">2025-10-06T21:34:08-05:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">

--- a/pc_builder/coverage/index.html
+++ b/pc_builder/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-10-06T15:37:18-05:00">2025-10-06T15:37:18-05:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-10-06T21:23:25-05:00">2025-10-06T21:23:25-05:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -22,14 +22,14 @@
     <span class="group_name">All Files</span>
     (<span class="covered_percent">
       <span class="green">
-  99.3%
+  98.33%
 </span>
 
      </span>
      covered at
      <span class="covered_strength">
        <span class="green">
-         16.18
+         15.96
        </span>
     </span> hits/line
     )
@@ -42,22 +42,22 @@
   </div>
 
   <div class="t-line-summary">
-    <b>711</b> relevant lines,
-    <span class="green"><b>706</b> lines covered</span> and
-    <span class="red"><b>5</b> lines missed. </span>
+    <b>719</b> relevant lines,
+    <span class="green"><b>707</b> lines covered</span> and
+    <span class="red"><b>12</b> lines missed. </span>
     (<span class="green">
-  99.3%
+  98.33%
 </span>
 )
   </div>
 
   
     <div class="t-branch-summary">
-      <span><b>222</b> total branches, </span>
+      <span><b>224</b> total branches, </span>
       <span class="green"><b>183</b> branches covered</span> and
-      <span class="red"><b>39</b> branches missed.</span>
+      <span class="red"><b>41</b> branches missed.</span>
       (<span class="yellow">
-  82.43%
+  81.7%
 </span>
 )
     </div>
@@ -85,7 +85,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1763b4eb3b3d2625cf8b272fc8c00fbb206cbc3e" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#0a1fed9587255776b1f2537aff81807821b114d8" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">98.51 %</td>
             <td class="cell--number">114</td>
             <td class="cell--number">67</td>
@@ -101,23 +101,23 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c5a7ed4ebd43c55ee32db214153de1ac246b6088" class="src_link" title="app/controllers/build_items_controller.rb">app/controllers/build_items_controller.rb</a></td>
-            <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">27</td>
-            <td class="cell--number">18</td>
-            <td class="cell--number">18</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">9.28</td>
+            <td class="strong t-file__name"><a href="#3d44df1e13ecfb264262164d07a86bace0c08bf9" class="src_link" title="app/controllers/build_items_controller.rb">app/controllers/build_items_controller.rb</a></td>
+            <td class="red strong cell--number t-file__coverage">73.08 %</td>
+            <td class="cell--number">42</td>
+            <td class="cell--number">26</td>
+            <td class="cell--number">19</td>
+            <td class="cell--number">7</td>
+            <td class="cell--number">6.46</td>
             
-              <td class="green strong cell--number t-file__branch-coverage">100.00 %</td>
+              <td class="red strong cell--number t-file__branch-coverage">50.00 %</td>
+              <td class="cell--number">4</td>
               <td class="cell--number">2</td>
               <td class="cell--number">2</td>
-              <td class="cell--number">0</td>
             
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c5eeec09feb230451738e58a948e8fc8547588f5" class="src_link" title="app/controllers/builds_controller.rb">app/controllers/builds_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#ba63067e5df333774b40b3712777d63357b89775" class="src_link" title="app/controllers/builds_controller.rb">app/controllers/builds_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">96.36 %</td>
             <td class="cell--number">204</td>
             <td class="cell--number">110</td>
@@ -133,7 +133,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#981fb11e7b36548d367a4b5fcadead019c16fead" class="src_link" title="app/controllers/coolers_controller.rb">app/controllers/coolers_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#801b8f874f6f17debb435eea865bc05ad51bf6b0" class="src_link" title="app/controllers/coolers_controller.rb">app/controllers/coolers_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -149,7 +149,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ec3f8eb8e156a939be079055a8402065fdc2049b" class="src_link" title="app/controllers/cpus_controller.rb">app/controllers/cpus_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#401853abbdcc053d1c258ca032b50d2c857cbd7f" class="src_link" title="app/controllers/cpus_controller.rb">app/controllers/cpus_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -165,7 +165,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d348b62263ec131683a3afe9b939c5f49770ed2d" class="src_link" title="app/controllers/gpus_controller.rb">app/controllers/gpus_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#ded48e4f0c6c4be3e25418f08b96365a70eb3a62" class="src_link" title="app/controllers/gpus_controller.rb">app/controllers/gpus_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -181,7 +181,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#002b1bb02fe03e26aa3aa9fc01cb9deca3d903dd" class="src_link" title="app/controllers/home_controller.rb">app/controllers/home_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#a9da8c7e598b0150b9b41739a68a628dbfdbe817" class="src_link" title="app/controllers/home_controller.rb">app/controllers/home_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">58</td>
             <td class="cell--number">25</td>
@@ -197,7 +197,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c9961ef647cfbc463e3b53b6f0dc39fd57a4a265" class="src_link" title="app/controllers/memories_controller.rb">app/controllers/memories_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#e482a1ead6c609a48c87e8dc5882f9e8aa39eb97" class="src_link" title="app/controllers/memories_controller.rb">app/controllers/memories_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -213,7 +213,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#987b9d3e39ff89682b7786d916095e43f951552b" class="src_link" title="app/controllers/motherboards_controller.rb">app/controllers/motherboards_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#0086ecd741bf9bde5808f9b835a849bb395985a6" class="src_link" title="app/controllers/motherboards_controller.rb">app/controllers/motherboards_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -229,7 +229,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1a96ccd7cd77c197e08f8023993e2e139d2b0b65" class="src_link" title="app/controllers/parts_controller.rb">app/controllers/parts_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#660047e358ef466991582f537072713bade6126d" class="src_link" title="app/controllers/parts_controller.rb">app/controllers/parts_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">92</td>
             <td class="cell--number">53</td>
@@ -245,7 +245,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c1f966ca47beb0a31ccbb25b87290e02b70e63f2" class="src_link" title="app/controllers/pc_cases_controller.rb">app/controllers/pc_cases_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#d70ad6b7c63e2fdb799c4f4d18e9e0c73d2c557d" class="src_link" title="app/controllers/pc_cases_controller.rb">app/controllers/pc_cases_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -261,7 +261,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#cfdbfb6e471cee5ea059ad653b51c3f819c29bf5" class="src_link" title="app/controllers/psus_controller.rb">app/controllers/psus_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#cb6ba1f1d1aceb150b0db7bd61b391e0bf4e2e79" class="src_link" title="app/controllers/psus_controller.rb">app/controllers/psus_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -277,7 +277,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#164d2494bfeab57e191885367cb468d210a27f8e" class="src_link" title="app/controllers/sessions_controller.rb">app/controllers/sessions_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#cfcb0aea391e0fc758e94ac8fc3978e8623e256f" class="src_link" title="app/controllers/sessions_controller.rb">app/controllers/sessions_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">61</td>
             <td class="cell--number">31</td>
@@ -293,7 +293,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5bd3cee7e7f27e5f953eb6cacba1e6378e685bcf" class="src_link" title="app/controllers/storages_controller.rb">app/controllers/storages_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#5cfb75257ea9c13e9f1382d08586da792837b213" class="src_link" title="app/controllers/storages_controller.rb">app/controllers/storages_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -309,7 +309,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#79cc6f751af71555a459a69cee532f7517e3a69b" class="src_link" title="app/controllers/users_controller.rb">app/controllers/users_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#166d512585846225fb6056e54bf7f3ef937384e6" class="src_link" title="app/controllers/users_controller.rb">app/controllers/users_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">68</td>
             <td class="cell--number">36</td>
@@ -325,7 +325,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#10a61281bbc380ce6a8b42a0116b1ae8b10aa470" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#5b7b1a3a3d5b4b80620da567f0be368ca562545e" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -341,7 +341,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#0c1c0393119a4b7d9bde26562bd31786ad58f3a3" class="src_link" title="app/helpers/build_items_helper.rb">app/helpers/build_items_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#2780ebfb185f0cc6d7ca7f338ee7922c7344fdef" class="src_link" title="app/helpers/build_items_helper.rb">app/helpers/build_items_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -357,7 +357,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#f06c27b971aefa4fef001c2cf477f7b3e0711ff6" class="src_link" title="app/helpers/builds_helper.rb">app/helpers/builds_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#62e50215b5ede25ec1091df345977fb146f87fdd" class="src_link" title="app/helpers/builds_helper.rb">app/helpers/builds_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -373,7 +373,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5afc8509200b4637ee5000990326207f5d5af0bd" class="src_link" title="app/helpers/coolers_helper.rb">app/helpers/coolers_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#d93a3c560bdd31b2bb4163c91dc191269cc763b8" class="src_link" title="app/helpers/coolers_helper.rb">app/helpers/coolers_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -389,7 +389,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#cf0abcb924d28c2bc0631a991c9225897030ea92" class="src_link" title="app/helpers/cpus_helper.rb">app/helpers/cpus_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#22a976b760c23c2556b0fd7340813852af88453d" class="src_link" title="app/helpers/cpus_helper.rb">app/helpers/cpus_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -405,7 +405,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#39ec99d6bacc8a73f8315c4b838fabee8c256ff1" class="src_link" title="app/helpers/gpus_helper.rb">app/helpers/gpus_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#026497fc8aea4d2a0b5b09a37140172c048d8c6d" class="src_link" title="app/helpers/gpus_helper.rb">app/helpers/gpus_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -421,7 +421,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e14ba149feb73e9bf90f61357ed677560a22df37" class="src_link" title="app/helpers/home_helper.rb">app/helpers/home_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#f24beec8bebe3d54bdbe523c7ac2cec019f20c61" class="src_link" title="app/helpers/home_helper.rb">app/helpers/home_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -437,7 +437,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d8042ffd5080c1ba51f3b1549e0900145692bd8e" class="src_link" title="app/helpers/memories_helper.rb">app/helpers/memories_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#57acc8bbbf9d9a1b08f5ad2b29e10373472fcc04" class="src_link" title="app/helpers/memories_helper.rb">app/helpers/memories_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -453,7 +453,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#94438b8a21f2eff72ace2684e9450d7ffeec423f" class="src_link" title="app/helpers/motherboards_helper.rb">app/helpers/motherboards_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#4242bc602d0286e84b3557b26d96043be5910eb4" class="src_link" title="app/helpers/motherboards_helper.rb">app/helpers/motherboards_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -469,7 +469,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#95234e3192e12b4f5ea11fc605eb5f400412140a" class="src_link" title="app/helpers/parts_helper.rb">app/helpers/parts_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#ea6181b8f6965297bb947c19db0224df65b2e803" class="src_link" title="app/helpers/parts_helper.rb">app/helpers/parts_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -485,7 +485,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#05b9dd5ea2b182218cbd1cbfaf8e288353eb7741" class="src_link" title="app/helpers/pc_cases_helper.rb">app/helpers/pc_cases_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#942fda0ccaded9538645b2de8c61868ab5939d83" class="src_link" title="app/helpers/pc_cases_helper.rb">app/helpers/pc_cases_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -501,7 +501,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7015bc60262cc29d20dd974eaf444c6728a3dea5" class="src_link" title="app/helpers/psus_helper.rb">app/helpers/psus_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#a69ef049b7f2d66b725d03ad64a6b44bfa347201" class="src_link" title="app/helpers/psus_helper.rb">app/helpers/psus_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -517,7 +517,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#9923167b8a093e7302fc8adc3caa3af560b8344a" class="src_link" title="app/helpers/storages_helper.rb">app/helpers/storages_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#e762f031c4e0f09d90e4445749840fc1601239ad" class="src_link" title="app/helpers/storages_helper.rb">app/helpers/storages_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -533,7 +533,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#583b78ecd00f459df215ca81486ba0c3b76c1f0f" class="src_link" title="app/helpers/users_helper.rb">app/helpers/users_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#2949b2c5f0883da66aec25dab10e9542818231f4" class="src_link" title="app/helpers/users_helper.rb">app/helpers/users_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -549,7 +549,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#44667995297b00346142747090ae043e9e61f6f8" class="src_link" title="app/jobs/application_job.rb">app/jobs/application_job.rb</a></td>
+            <td class="strong t-file__name"><a href="#796f40a8c28bf893f0c49d5702f7bc5cbffcee97" class="src_link" title="app/jobs/application_job.rb">app/jobs/application_job.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">7</td>
             <td class="cell--number">1</td>
@@ -565,7 +565,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1aa3853dbfb027d0017bf5edbb1c414ef6d59080" class="src_link" title="app/lib/database_logger.rb">app/lib/database_logger.rb</a></td>
+            <td class="strong t-file__name"><a href="#5aae5bb18a6e19a6840e2d8cd06c77b6d6494c24" class="src_link" title="app/lib/database_logger.rb">app/lib/database_logger.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">94</td>
             <td class="cell--number">48</td>
@@ -581,7 +581,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#765aae32b9742bd136427432800d710d2a5405e5" class="src_link" title="app/lib/logging_helpers.rb">app/lib/logging_helpers.rb</a></td>
+            <td class="strong t-file__name"><a href="#5c6fc5f50b0404fe4c7b450b2443d45ec6d8d395" class="src_link" title="app/lib/logging_helpers.rb">app/lib/logging_helpers.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">135</td>
             <td class="cell--number">69</td>
@@ -597,7 +597,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7a7645d6863108a6453ba9a9a4fda9853b82f960" class="src_link" title="app/mailers/application_mailer.rb">app/mailers/application_mailer.rb</a></td>
+            <td class="strong t-file__name"><a href="#d5b771c54823b86647681e962553185e359f41db" class="src_link" title="app/mailers/application_mailer.rb">app/mailers/application_mailer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">3</td>
@@ -613,7 +613,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e384f49354dea39fa2141748ee0a5f2da57f51f6" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
+            <td class="strong t-file__name"><a href="#f8c5bea73d2ae172d2b11cc8604dfffd74858f3b" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">3</td>
             <td class="cell--number">2</td>
@@ -629,13 +629,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5e6d6683e6883675cad3df6b8232140647eb0123" class="src_link" title="app/models/build.rb">app/models/build.rb</a></td>
+            <td class="strong t-file__name"><a href="#6b83102bdb009ff7eed151af3fea774e325856d1" class="src_link" title="app/models/build.rb">app/models/build.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">106</td>
+            <td class="cell--number">107</td>
             <td class="cell--number">58</td>
             <td class="cell--number">58</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">12.60</td>
+            <td class="cell--number">12.41</td>
             
               <td class="yellow strong cell--number t-file__branch-coverage">90.00 %</td>
               <td class="cell--number">10</td>
@@ -645,13 +645,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#a6ea01ffcc22b871034feba95b40891bccd98607" class="src_link" title="app/models/build_item.rb">app/models/build_item.rb</a></td>
+            <td class="strong t-file__name"><a href="#d59bb4c0d707b5ed9b277cd4d0c561e1f0b8c8a6" class="src_link" title="app/models/build_item.rb">app/models/build_item.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">52</td>
             <td class="cell--number">31</td>
             <td class="cell--number">31</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">11.65</td>
+            <td class="cell--number">11.52</td>
             
               <td class="red strong cell--number t-file__branch-coverage">62.50 %</td>
               <td class="cell--number">8</td>
@@ -661,7 +661,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#fd561b56139273ce7d169e4c35e2ee32271757d9" class="src_link" title="app/models/cooler.rb">app/models/cooler.rb</a></td>
+            <td class="strong t-file__name"><a href="#4cbf548a4698b4512e67d7a9d4c757598aa486bd" class="src_link" title="app/models/cooler.rb">app/models/cooler.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -677,13 +677,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#8e601589d06da1335572bcc028065843ef8c1f8b" class="src_link" title="app/models/cpu.rb">app/models/cpu.rb</a></td>
+            <td class="strong t-file__name"><a href="#8b3ba20ea8c12d9b828f610391b939d01b35cb24" class="src_link" title="app/models/cpu.rb">app/models/cpu.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">25</td>
             <td class="cell--number">13</td>
             <td class="cell--number">13</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">33.77</td>
+            <td class="cell--number">33.54</td>
             
               <td class="green strong cell--number t-file__branch-coverage">100.00 %</td>
               <td class="cell--number">4</td>
@@ -693,7 +693,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#11689a41889722db21550a5bb933f7719ac3c508" class="src_link" title="app/models/gpu.rb">app/models/gpu.rb</a></td>
+            <td class="strong t-file__name"><a href="#c1d6ee4dfd0d6d0d7db987a14e0c161b55bf242b" class="src_link" title="app/models/gpu.rb">app/models/gpu.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -709,7 +709,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#be91a57a65867a529dbac40fb97d190ec01d7199" class="src_link" title="app/models/memory.rb">app/models/memory.rb</a></td>
+            <td class="strong t-file__name"><a href="#033632b9d0cb3022330019d67bbd728ff5e4891a" class="src_link" title="app/models/memory.rb">app/models/memory.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -725,7 +725,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7df4e3637487f910ebad4a0ddbe8ebea4790923b" class="src_link" title="app/models/motherboard.rb">app/models/motherboard.rb</a></td>
+            <td class="strong t-file__name"><a href="#030399f4d2b4becd3cd169d8119cf41eddab3185" class="src_link" title="app/models/motherboard.rb">app/models/motherboard.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -741,13 +741,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#233062ed4f8b817c5593388fb130e9091b540063" class="src_link" title="app/models/part.rb">app/models/part.rb</a></td>
+            <td class="strong t-file__name"><a href="#501421c4718ae347e1d6d75f5d629bdb3d7e3695" class="src_link" title="app/models/part.rb">app/models/part.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">63</td>
             <td class="cell--number">40</td>
             <td class="cell--number">40</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">67.80</td>
+            <td class="cell--number">67.60</td>
             
               <td class="yellow strong cell--number t-file__branch-coverage">90.00 %</td>
               <td class="cell--number">10</td>
@@ -757,7 +757,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7ec65b88696dad5c0c6973f2ecfc953341ed4e9d" class="src_link" title="app/models/pc_case.rb">app/models/pc_case.rb</a></td>
+            <td class="strong t-file__name"><a href="#3d161f24e9aa63ff1b594bc23caf624078ebcc6b" class="src_link" title="app/models/pc_case.rb">app/models/pc_case.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">2</td>
@@ -773,7 +773,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ca59c035338f6991311d2887b2a63b97ce9732c4" class="src_link" title="app/models/psu.rb">app/models/psu.rb</a></td>
+            <td class="strong t-file__name"><a href="#ba70f1581be9eddaee6df72d46819d0dfdcd8189" class="src_link" title="app/models/psu.rb">app/models/psu.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -789,7 +789,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d85467a8d9417185fedcd413fb3a6e3badefaf7b" class="src_link" title="app/models/storage.rb">app/models/storage.rb</a></td>
+            <td class="strong t-file__name"><a href="#b1aa564c85e01780ee6a26873d90b75e17e1e348" class="src_link" title="app/models/storage.rb">app/models/storage.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -805,13 +805,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#a46f1cdb109e44f3f545ec434d2d5033c676d168" class="src_link" title="app/models/user.rb">app/models/user.rb</a></td>
+            <td class="strong t-file__name"><a href="#9cf8fba569c21d036033814a406009d53184f04f" class="src_link" title="app/models/user.rb">app/models/user.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">67</td>
             <td class="cell--number">36</td>
             <td class="cell--number">36</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">39.08</td>
+            <td class="cell--number">38.86</td>
             
               <td class="green strong cell--number t-file__branch-coverage">100.00 %</td>
               <td class="cell--number">4</td>
@@ -832,14 +832,14 @@
     <span class="group_name">Controllers</span>
     (<span class="covered_percent">
       <span class="green">
-  98.71%
+  96.97%
 </span>
 
      </span>
      covered at
      <span class="covered_strength">
        <span class="green">
-         13.67
+         13.4
        </span>
     </span> hits/line
     )
@@ -852,22 +852,22 @@
   </div>
 
   <div class="t-line-summary">
-    <b>388</b> relevant lines,
-    <span class="green"><b>383</b> lines covered</span> and
-    <span class="red"><b>5</b> lines missed. </span>
+    <b>396</b> relevant lines,
+    <span class="green"><b>384</b> lines covered</span> and
+    <span class="red"><b>12</b> lines missed. </span>
     (<span class="green">
-  98.71%
+  96.97%
 </span>
 )
   </div>
 
   
     <div class="t-branch-summary">
-      <span><b>135</b> total branches, </span>
+      <span><b>137</b> total branches, </span>
       <span class="green"><b>106</b> branches covered</span> and
-      <span class="red"><b>29</b> branches missed.</span>
+      <span class="red"><b>31</b> branches missed.</span>
       (<span class="red">
-  78.52%
+  77.37%
 </span>
 )
     </div>
@@ -895,7 +895,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1763b4eb3b3d2625cf8b272fc8c00fbb206cbc3e" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#0a1fed9587255776b1f2537aff81807821b114d8" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">98.51 %</td>
             <td class="cell--number">114</td>
             <td class="cell--number">67</td>
@@ -911,23 +911,23 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c5a7ed4ebd43c55ee32db214153de1ac246b6088" class="src_link" title="app/controllers/build_items_controller.rb">app/controllers/build_items_controller.rb</a></td>
-            <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">27</td>
-            <td class="cell--number">18</td>
-            <td class="cell--number">18</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">9.28</td>
+            <td class="strong t-file__name"><a href="#3d44df1e13ecfb264262164d07a86bace0c08bf9" class="src_link" title="app/controllers/build_items_controller.rb">app/controllers/build_items_controller.rb</a></td>
+            <td class="red strong cell--number t-file__coverage">73.08 %</td>
+            <td class="cell--number">42</td>
+            <td class="cell--number">26</td>
+            <td class="cell--number">19</td>
+            <td class="cell--number">7</td>
+            <td class="cell--number">6.46</td>
             
-              <td class="green strong cell--number t-file__branch-coverage">100.00 %</td>
+              <td class="red strong cell--number t-file__branch-coverage">50.00 %</td>
+              <td class="cell--number">4</td>
               <td class="cell--number">2</td>
               <td class="cell--number">2</td>
-              <td class="cell--number">0</td>
             
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c5eeec09feb230451738e58a948e8fc8547588f5" class="src_link" title="app/controllers/builds_controller.rb">app/controllers/builds_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#ba63067e5df333774b40b3712777d63357b89775" class="src_link" title="app/controllers/builds_controller.rb">app/controllers/builds_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">96.36 %</td>
             <td class="cell--number">204</td>
             <td class="cell--number">110</td>
@@ -943,7 +943,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#981fb11e7b36548d367a4b5fcadead019c16fead" class="src_link" title="app/controllers/coolers_controller.rb">app/controllers/coolers_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#801b8f874f6f17debb435eea865bc05ad51bf6b0" class="src_link" title="app/controllers/coolers_controller.rb">app/controllers/coolers_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -959,7 +959,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ec3f8eb8e156a939be079055a8402065fdc2049b" class="src_link" title="app/controllers/cpus_controller.rb">app/controllers/cpus_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#401853abbdcc053d1c258ca032b50d2c857cbd7f" class="src_link" title="app/controllers/cpus_controller.rb">app/controllers/cpus_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -975,7 +975,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d348b62263ec131683a3afe9b939c5f49770ed2d" class="src_link" title="app/controllers/gpus_controller.rb">app/controllers/gpus_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#ded48e4f0c6c4be3e25418f08b96365a70eb3a62" class="src_link" title="app/controllers/gpus_controller.rb">app/controllers/gpus_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -991,7 +991,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#002b1bb02fe03e26aa3aa9fc01cb9deca3d903dd" class="src_link" title="app/controllers/home_controller.rb">app/controllers/home_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#a9da8c7e598b0150b9b41739a68a628dbfdbe817" class="src_link" title="app/controllers/home_controller.rb">app/controllers/home_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">58</td>
             <td class="cell--number">25</td>
@@ -1007,7 +1007,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c9961ef647cfbc463e3b53b6f0dc39fd57a4a265" class="src_link" title="app/controllers/memories_controller.rb">app/controllers/memories_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#e482a1ead6c609a48c87e8dc5882f9e8aa39eb97" class="src_link" title="app/controllers/memories_controller.rb">app/controllers/memories_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -1023,7 +1023,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#987b9d3e39ff89682b7786d916095e43f951552b" class="src_link" title="app/controllers/motherboards_controller.rb">app/controllers/motherboards_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#0086ecd741bf9bde5808f9b835a849bb395985a6" class="src_link" title="app/controllers/motherboards_controller.rb">app/controllers/motherboards_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -1039,7 +1039,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1a96ccd7cd77c197e08f8023993e2e139d2b0b65" class="src_link" title="app/controllers/parts_controller.rb">app/controllers/parts_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#660047e358ef466991582f537072713bade6126d" class="src_link" title="app/controllers/parts_controller.rb">app/controllers/parts_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">92</td>
             <td class="cell--number">53</td>
@@ -1055,7 +1055,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c1f966ca47beb0a31ccbb25b87290e02b70e63f2" class="src_link" title="app/controllers/pc_cases_controller.rb">app/controllers/pc_cases_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#d70ad6b7c63e2fdb799c4f4d18e9e0c73d2c557d" class="src_link" title="app/controllers/pc_cases_controller.rb">app/controllers/pc_cases_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -1071,7 +1071,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#cfdbfb6e471cee5ea059ad653b51c3f819c29bf5" class="src_link" title="app/controllers/psus_controller.rb">app/controllers/psus_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#cb6ba1f1d1aceb150b0db7bd61b391e0bf4e2e79" class="src_link" title="app/controllers/psus_controller.rb">app/controllers/psus_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -1087,7 +1087,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#164d2494bfeab57e191885367cb468d210a27f8e" class="src_link" title="app/controllers/sessions_controller.rb">app/controllers/sessions_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#cfcb0aea391e0fc758e94ac8fc3978e8623e256f" class="src_link" title="app/controllers/sessions_controller.rb">app/controllers/sessions_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">61</td>
             <td class="cell--number">31</td>
@@ -1103,7 +1103,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5bd3cee7e7f27e5f953eb6cacba1e6378e685bcf" class="src_link" title="app/controllers/storages_controller.rb">app/controllers/storages_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#5cfb75257ea9c13e9f1382d08586da792837b213" class="src_link" title="app/controllers/storages_controller.rb">app/controllers/storages_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">6</td>
@@ -1119,7 +1119,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#79cc6f751af71555a459a69cee532f7517e3a69b" class="src_link" title="app/controllers/users_controller.rb">app/controllers/users_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#166d512585846225fb6056e54bf7f3ef937384e6" class="src_link" title="app/controllers/users_controller.rb">app/controllers/users_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">68</td>
             <td class="cell--number">36</td>
@@ -1225,7 +1225,7 @@
      covered at
      <span class="covered_strength">
        <span class="green">
-         30.11
+         29.93
        </span>
     </span> hits/line
     )
@@ -1281,7 +1281,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e384f49354dea39fa2141748ee0a5f2da57f51f6" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
+            <td class="strong t-file__name"><a href="#f8c5bea73d2ae172d2b11cc8604dfffd74858f3b" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">3</td>
             <td class="cell--number">2</td>
@@ -1297,13 +1297,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5e6d6683e6883675cad3df6b8232140647eb0123" class="src_link" title="app/models/build.rb">app/models/build.rb</a></td>
+            <td class="strong t-file__name"><a href="#6b83102bdb009ff7eed151af3fea774e325856d1" class="src_link" title="app/models/build.rb">app/models/build.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">106</td>
+            <td class="cell--number">107</td>
             <td class="cell--number">58</td>
             <td class="cell--number">58</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">12.60</td>
+            <td class="cell--number">12.41</td>
             
               <td class="yellow strong cell--number t-file__branch-coverage">90.00 %</td>
               <td class="cell--number">10</td>
@@ -1313,13 +1313,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#a6ea01ffcc22b871034feba95b40891bccd98607" class="src_link" title="app/models/build_item.rb">app/models/build_item.rb</a></td>
+            <td class="strong t-file__name"><a href="#d59bb4c0d707b5ed9b277cd4d0c561e1f0b8c8a6" class="src_link" title="app/models/build_item.rb">app/models/build_item.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">52</td>
             <td class="cell--number">31</td>
             <td class="cell--number">31</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">11.65</td>
+            <td class="cell--number">11.52</td>
             
               <td class="red strong cell--number t-file__branch-coverage">62.50 %</td>
               <td class="cell--number">8</td>
@@ -1329,7 +1329,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#fd561b56139273ce7d169e4c35e2ee32271757d9" class="src_link" title="app/models/cooler.rb">app/models/cooler.rb</a></td>
+            <td class="strong t-file__name"><a href="#4cbf548a4698b4512e67d7a9d4c757598aa486bd" class="src_link" title="app/models/cooler.rb">app/models/cooler.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1345,13 +1345,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#8e601589d06da1335572bcc028065843ef8c1f8b" class="src_link" title="app/models/cpu.rb">app/models/cpu.rb</a></td>
+            <td class="strong t-file__name"><a href="#8b3ba20ea8c12d9b828f610391b939d01b35cb24" class="src_link" title="app/models/cpu.rb">app/models/cpu.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">25</td>
             <td class="cell--number">13</td>
             <td class="cell--number">13</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">33.77</td>
+            <td class="cell--number">33.54</td>
             
               <td class="green strong cell--number t-file__branch-coverage">100.00 %</td>
               <td class="cell--number">4</td>
@@ -1361,7 +1361,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#11689a41889722db21550a5bb933f7719ac3c508" class="src_link" title="app/models/gpu.rb">app/models/gpu.rb</a></td>
+            <td class="strong t-file__name"><a href="#c1d6ee4dfd0d6d0d7db987a14e0c161b55bf242b" class="src_link" title="app/models/gpu.rb">app/models/gpu.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1377,7 +1377,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#be91a57a65867a529dbac40fb97d190ec01d7199" class="src_link" title="app/models/memory.rb">app/models/memory.rb</a></td>
+            <td class="strong t-file__name"><a href="#033632b9d0cb3022330019d67bbd728ff5e4891a" class="src_link" title="app/models/memory.rb">app/models/memory.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1393,7 +1393,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7df4e3637487f910ebad4a0ddbe8ebea4790923b" class="src_link" title="app/models/motherboard.rb">app/models/motherboard.rb</a></td>
+            <td class="strong t-file__name"><a href="#030399f4d2b4becd3cd169d8119cf41eddab3185" class="src_link" title="app/models/motherboard.rb">app/models/motherboard.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1409,13 +1409,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#233062ed4f8b817c5593388fb130e9091b540063" class="src_link" title="app/models/part.rb">app/models/part.rb</a></td>
+            <td class="strong t-file__name"><a href="#501421c4718ae347e1d6d75f5d629bdb3d7e3695" class="src_link" title="app/models/part.rb">app/models/part.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">63</td>
             <td class="cell--number">40</td>
             <td class="cell--number">40</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">67.80</td>
+            <td class="cell--number">67.60</td>
             
               <td class="yellow strong cell--number t-file__branch-coverage">90.00 %</td>
               <td class="cell--number">10</td>
@@ -1425,7 +1425,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7ec65b88696dad5c0c6973f2ecfc953341ed4e9d" class="src_link" title="app/models/pc_case.rb">app/models/pc_case.rb</a></td>
+            <td class="strong t-file__name"><a href="#3d161f24e9aa63ff1b594bc23caf624078ebcc6b" class="src_link" title="app/models/pc_case.rb">app/models/pc_case.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">2</td>
@@ -1441,7 +1441,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#ca59c035338f6991311d2887b2a63b97ce9732c4" class="src_link" title="app/models/psu.rb">app/models/psu.rb</a></td>
+            <td class="strong t-file__name"><a href="#ba70f1581be9eddaee6df72d46819d0dfdcd8189" class="src_link" title="app/models/psu.rb">app/models/psu.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1457,7 +1457,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d85467a8d9417185fedcd413fb3a6e3badefaf7b" class="src_link" title="app/models/storage.rb">app/models/storage.rb</a></td>
+            <td class="strong t-file__name"><a href="#b1aa564c85e01780ee6a26873d90b75e17e1e348" class="src_link" title="app/models/storage.rb">app/models/storage.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1473,13 +1473,13 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#a46f1cdb109e44f3f545ec434d2d5033c676d168" class="src_link" title="app/models/user.rb">app/models/user.rb</a></td>
+            <td class="strong t-file__name"><a href="#9cf8fba569c21d036033814a406009d53184f04f" class="src_link" title="app/models/user.rb">app/models/user.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">67</td>
             <td class="cell--number">36</td>
             <td class="cell--number">36</td>
             <td class="cell--number">0</td>
-            <td class="cell--number">39.08</td>
+            <td class="cell--number">38.86</td>
             
               <td class="green strong cell--number t-file__branch-coverage">100.00 %</td>
               <td class="cell--number">4</td>
@@ -1562,7 +1562,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7a7645d6863108a6453ba9a9a4fda9853b82f960" class="src_link" title="app/mailers/application_mailer.rb">app/mailers/application_mailer.rb</a></td>
+            <td class="strong t-file__name"><a href="#d5b771c54823b86647681e962553185e359f41db" class="src_link" title="app/mailers/application_mailer.rb">app/mailers/application_mailer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">3</td>
@@ -1651,7 +1651,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#10a61281bbc380ce6a8b42a0116b1ae8b10aa470" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#5b7b1a3a3d5b4b80620da567f0be368ca562545e" class="src_link" title="app/helpers/application_helper.rb">app/helpers/application_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1667,7 +1667,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#0c1c0393119a4b7d9bde26562bd31786ad58f3a3" class="src_link" title="app/helpers/build_items_helper.rb">app/helpers/build_items_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#2780ebfb185f0cc6d7ca7f338ee7922c7344fdef" class="src_link" title="app/helpers/build_items_helper.rb">app/helpers/build_items_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1683,7 +1683,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#f06c27b971aefa4fef001c2cf477f7b3e0711ff6" class="src_link" title="app/helpers/builds_helper.rb">app/helpers/builds_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#62e50215b5ede25ec1091df345977fb146f87fdd" class="src_link" title="app/helpers/builds_helper.rb">app/helpers/builds_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1699,7 +1699,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5afc8509200b4637ee5000990326207f5d5af0bd" class="src_link" title="app/helpers/coolers_helper.rb">app/helpers/coolers_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#d93a3c560bdd31b2bb4163c91dc191269cc763b8" class="src_link" title="app/helpers/coolers_helper.rb">app/helpers/coolers_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1715,7 +1715,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#cf0abcb924d28c2bc0631a991c9225897030ea92" class="src_link" title="app/helpers/cpus_helper.rb">app/helpers/cpus_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#22a976b760c23c2556b0fd7340813852af88453d" class="src_link" title="app/helpers/cpus_helper.rb">app/helpers/cpus_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1731,7 +1731,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#39ec99d6bacc8a73f8315c4b838fabee8c256ff1" class="src_link" title="app/helpers/gpus_helper.rb">app/helpers/gpus_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#026497fc8aea4d2a0b5b09a37140172c048d8c6d" class="src_link" title="app/helpers/gpus_helper.rb">app/helpers/gpus_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1747,7 +1747,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e14ba149feb73e9bf90f61357ed677560a22df37" class="src_link" title="app/helpers/home_helper.rb">app/helpers/home_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#f24beec8bebe3d54bdbe523c7ac2cec019f20c61" class="src_link" title="app/helpers/home_helper.rb">app/helpers/home_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1763,7 +1763,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d8042ffd5080c1ba51f3b1549e0900145692bd8e" class="src_link" title="app/helpers/memories_helper.rb">app/helpers/memories_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#57acc8bbbf9d9a1b08f5ad2b29e10373472fcc04" class="src_link" title="app/helpers/memories_helper.rb">app/helpers/memories_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1779,7 +1779,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#94438b8a21f2eff72ace2684e9450d7ffeec423f" class="src_link" title="app/helpers/motherboards_helper.rb">app/helpers/motherboards_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#4242bc602d0286e84b3557b26d96043be5910eb4" class="src_link" title="app/helpers/motherboards_helper.rb">app/helpers/motherboards_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1795,7 +1795,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#95234e3192e12b4f5ea11fc605eb5f400412140a" class="src_link" title="app/helpers/parts_helper.rb">app/helpers/parts_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#ea6181b8f6965297bb947c19db0224df65b2e803" class="src_link" title="app/helpers/parts_helper.rb">app/helpers/parts_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1811,7 +1811,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#05b9dd5ea2b182218cbd1cbfaf8e288353eb7741" class="src_link" title="app/helpers/pc_cases_helper.rb">app/helpers/pc_cases_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#942fda0ccaded9538645b2de8c61868ab5939d83" class="src_link" title="app/helpers/pc_cases_helper.rb">app/helpers/pc_cases_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1827,7 +1827,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7015bc60262cc29d20dd974eaf444c6728a3dea5" class="src_link" title="app/helpers/psus_helper.rb">app/helpers/psus_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#a69ef049b7f2d66b725d03ad64a6b44bfa347201" class="src_link" title="app/helpers/psus_helper.rb">app/helpers/psus_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1843,7 +1843,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#9923167b8a093e7302fc8adc3caa3af560b8344a" class="src_link" title="app/helpers/storages_helper.rb">app/helpers/storages_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#e762f031c4e0f09d90e4445749840fc1601239ad" class="src_link" title="app/helpers/storages_helper.rb">app/helpers/storages_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1859,7 +1859,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#583b78ecd00f459df215ca81486ba0c3b76c1f0f" class="src_link" title="app/helpers/users_helper.rb">app/helpers/users_helper.rb</a></td>
+            <td class="strong t-file__name"><a href="#2949b2c5f0883da66aec25dab10e9542818231f4" class="src_link" title="app/helpers/users_helper.rb">app/helpers/users_helper.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -1948,7 +1948,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#44667995297b00346142747090ae043e9e61f6f8" class="src_link" title="app/jobs/application_job.rb">app/jobs/application_job.rb</a></td>
+            <td class="strong t-file__name"><a href="#796f40a8c28bf893f0c49d5702f7bc5cbffcee97" class="src_link" title="app/jobs/application_job.rb">app/jobs/application_job.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">7</td>
             <td class="cell--number">1</td>
@@ -2037,7 +2037,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1aa3853dbfb027d0017bf5edbb1c414ef6d59080" class="src_link" title="app/lib/database_logger.rb">app/lib/database_logger.rb</a></td>
+            <td class="strong t-file__name"><a href="#5aae5bb18a6e19a6840e2d8cd06c77b6d6494c24" class="src_link" title="app/lib/database_logger.rb">app/lib/database_logger.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">94</td>
             <td class="cell--number">48</td>
@@ -2053,7 +2053,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#765aae32b9742bd136427432800d710d2a5405e5" class="src_link" title="app/lib/logging_helpers.rb">app/lib/logging_helpers.rb</a></td>
+            <td class="strong t-file__name"><a href="#5c6fc5f50b0404fe4c7b450b2443d45ec6d8d395" class="src_link" title="app/lib/logging_helpers.rb">app/lib/logging_helpers.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">135</td>
             <td class="cell--number">69</td>
@@ -2084,7 +2084,7 @@
 
       <div class="source_files">
       
-        <div class="source_table" id="1763b4eb3b3d2625cf8b272fc8c00fbb206cbc3e">
+        <div class="source_table" id="0a1fed9587255776b1f2537aff81807821b114d8">
   <div class="header">
     <h3>app/controllers/application_controller.rb</h3>
     <h4>
@@ -3757,12 +3757,12 @@
 </div>
 
       
-        <div class="source_table" id="c5a7ed4ebd43c55ee32db214153de1ac246b6088">
+        <div class="source_table" id="3d44df1e13ecfb264262164d07a86bace0c08bf9">
   <div class="header">
     <h3>app/controllers/build_items_controller.rb</h3>
     <h4>
-      <span class="green">
-  100.0%
+      <span class="red">
+  73.08%
 </span>
 
       lines covered
@@ -3770,8 +3770,8 @@
 
     
       <h4>
-        <span class="green">
-  100.0%
+        <span class="red">
+  50.0%
 </span>
 
         branches covered
@@ -3779,16 +3779,16 @@
     
 
     <div class="t-line-summary">
-      <b>18</b> relevant lines.
-      <span class="green"><b>18</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <b>26</b> relevant lines.
+      <span class="green"><b>19</b> lines covered</span> and
+      <span class="red"><b>7</b> lines missed.</span>
     </div>
 
     
       <div class="t-branch-summary">
-          <span><b>2</b> total branches, </span>
+          <span><b>4</b> total branches, </span>
           <span class="green"><b>2</b> branches covered</span> and
-          <span class="red"><b>0</b> branches missed.</span>
+          <span class="red"><b>2</b> branches missed.</span>
       </div>
     
 
@@ -4161,6 +4161,196 @@
               
             
 
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="28">
+            
+
+            
+              
+            
+
+            <code class="ruby">  # ADDED: New method to handle removing a part from a build</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="29">
+            
+              <span class="hits">1</span>
+            
+
+            
+              
+            
+
+            <code class="ruby">  def destroy</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="30">
+            
+
+            
+              
+            
+
+            <code class="ruby">    @build = Build.find(params[:build_id])</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="31">
+            
+
+            
+              
+            
+
+            <code class="ruby">    @build_item = @build.build_items.find(params[:id])</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="32">
+            
+
+            
+              
+            
+
+            <code class="ruby">    part_name = @build_item.part.name</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="33">
+            
+
+            
+              
+            
+
+            <code class="ruby">    </code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed-branch" data-hits="0" data-linenumber="34">
+            
+
+            
+              
+                <span class="hits" title="then branch hit 0 times">
+                  then: 0
+                </span>
+              
+            
+
+            <code class="ruby">    if @build_item.destroy</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="35">
+            
+
+            
+              
+            
+
+            <code class="ruby">      flash[:notice] = &quot;#{part_name} was successfully removed from your build.&quot;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed-branch" data-hits="" data-linenumber="36">
+            
+
+            
+              
+                <span class="hits" title="else branch hit 0 times">
+                  else: 0
+                </span>
+              
+            
+
+            <code class="ruby">    else</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="37">
+            
+
+            
+              
+            
+
+            <code class="ruby">      flash[:alert] = &quot;Failed to remove #{part_name}.&quot;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="38">
+            
+
+            
+              
+            
+
+            <code class="ruby">    end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="39">
+            
+
+            
+              
+            
+
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="40">
+            
+
+            
+              
+            
+
+            <code class="ruby">    redirect_to build_path(@build), status: :see_other</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="41">
+            
+
+            
+              
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="42">
+            
+
+            
+              
+            
+
             <code class="ruby">end</code>
           </li>
         </div>
@@ -4170,7 +4360,7 @@
 </div>
 
       
-        <div class="source_table" id="c5eeec09feb230451738e58a948e8fc8547588f5">
+        <div class="source_table" id="ba63067e5df333774b40b3712777d63357b89775">
   <div class="header">
     <h3>app/controllers/builds_controller.rb</h3>
     <h4>
@@ -7083,7 +7273,7 @@
 </div>
 
       
-        <div class="source_table" id="981fb11e7b36548d367a4b5fcadead019c16fead">
+        <div class="source_table" id="801b8f874f6f17debb435eea865bc05ad51bf6b0">
   <div class="header">
     <h3>app/controllers/coolers_controller.rb</h3>
     <h4>
@@ -7272,7 +7462,7 @@
 </div>
 
       
-        <div class="source_table" id="ec3f8eb8e156a939be079055a8402065fdc2049b">
+        <div class="source_table" id="401853abbdcc053d1c258ca032b50d2c857cbd7f">
   <div class="header">
     <h3>app/controllers/cpus_controller.rb</h3>
     <h4>
@@ -7461,7 +7651,7 @@
 </div>
 
       
-        <div class="source_table" id="d348b62263ec131683a3afe9b939c5f49770ed2d">
+        <div class="source_table" id="ded48e4f0c6c4be3e25418f08b96365a70eb3a62">
   <div class="header">
     <h3>app/controllers/gpus_controller.rb</h3>
     <h4>
@@ -7650,7 +7840,7 @@
 </div>
 
       
-        <div class="source_table" id="002b1bb02fe03e26aa3aa9fc01cb9deca3d903dd">
+        <div class="source_table" id="a9da8c7e598b0150b9b41739a68a628dbfdbe817">
   <div class="header">
     <h3>app/controllers/home_controller.rb</h3>
     <h4>
@@ -8465,7 +8655,7 @@
 </div>
 
       
-        <div class="source_table" id="c9961ef647cfbc463e3b53b6f0dc39fd57a4a265">
+        <div class="source_table" id="e482a1ead6c609a48c87e8dc5882f9e8aa39eb97">
   <div class="header">
     <h3>app/controllers/memories_controller.rb</h3>
     <h4>
@@ -8654,7 +8844,7 @@
 </div>
 
       
-        <div class="source_table" id="987b9d3e39ff89682b7786d916095e43f951552b">
+        <div class="source_table" id="0086ecd741bf9bde5808f9b835a849bb395985a6">
   <div class="header">
     <h3>app/controllers/motherboards_controller.rb</h3>
     <h4>
@@ -8843,7 +9033,7 @@
 </div>
 
       
-        <div class="source_table" id="1a96ccd7cd77c197e08f8023993e2e139d2b0b65">
+        <div class="source_table" id="660047e358ef466991582f537072713bade6126d">
   <div class="header">
     <h3>app/controllers/parts_controller.rb</h3>
     <h4>
@@ -10206,7 +10396,7 @@
 </div>
 
       
-        <div class="source_table" id="c1f966ca47beb0a31ccbb25b87290e02b70e63f2">
+        <div class="source_table" id="d70ad6b7c63e2fdb799c4f4d18e9e0c73d2c557d">
   <div class="header">
     <h3>app/controllers/pc_cases_controller.rb</h3>
     <h4>
@@ -10395,7 +10585,7 @@
 </div>
 
       
-        <div class="source_table" id="cfdbfb6e471cee5ea059ad653b51c3f819c29bf5">
+        <div class="source_table" id="cb6ba1f1d1aceb150b0db7bd61b391e0bf4e2e79">
   <div class="header">
     <h3>app/controllers/psus_controller.rb</h3>
     <h4>
@@ -10584,7 +10774,7 @@
 </div>
 
       
-        <div class="source_table" id="164d2494bfeab57e191885367cb468d210a27f8e">
+        <div class="source_table" id="cfcb0aea391e0fc758e94ac8fc3978e8623e256f">
   <div class="header">
     <h3>app/controllers/sessions_controller.rb</h3>
     <h4>
@@ -11447,7 +11637,7 @@
 </div>
 
       
-        <div class="source_table" id="5bd3cee7e7f27e5f953eb6cacba1e6378e685bcf">
+        <div class="source_table" id="5cfb75257ea9c13e9f1382d08586da792837b213">
   <div class="header">
     <h3>app/controllers/storages_controller.rb</h3>
     <h4>
@@ -11636,7 +11826,7 @@
 </div>
 
       
-        <div class="source_table" id="79cc6f751af71555a459a69cee532f7517e3a69b">
+        <div class="source_table" id="166d512585846225fb6056e54bf7f3ef937384e6">
   <div class="header">
     <h3>app/controllers/users_controller.rb</h3>
     <h4>
@@ -12609,7 +12799,7 @@
 </div>
 
       
-        <div class="source_table" id="10a61281bbc380ce6a8b42a0116b1ae8b10aa470">
+        <div class="source_table" id="5b7b1a3a3d5b4b80620da567f0be368ca562545e">
   <div class="header">
     <h3>app/helpers/application_helper.rb</h3>
     <h4>
@@ -12680,7 +12870,7 @@
 </div>
 
       
-        <div class="source_table" id="0c1c0393119a4b7d9bde26562bd31786ad58f3a3">
+        <div class="source_table" id="2780ebfb185f0cc6d7ca7f338ee7922c7344fdef">
   <div class="header">
     <h3>app/helpers/build_items_helper.rb</h3>
     <h4>
@@ -12751,7 +12941,7 @@
 </div>
 
       
-        <div class="source_table" id="f06c27b971aefa4fef001c2cf477f7b3e0711ff6">
+        <div class="source_table" id="62e50215b5ede25ec1091df345977fb146f87fdd">
   <div class="header">
     <h3>app/helpers/builds_helper.rb</h3>
     <h4>
@@ -12822,7 +13012,7 @@
 </div>
 
       
-        <div class="source_table" id="5afc8509200b4637ee5000990326207f5d5af0bd">
+        <div class="source_table" id="d93a3c560bdd31b2bb4163c91dc191269cc763b8">
   <div class="header">
     <h3>app/helpers/coolers_helper.rb</h3>
     <h4>
@@ -12893,7 +13083,7 @@
 </div>
 
       
-        <div class="source_table" id="cf0abcb924d28c2bc0631a991c9225897030ea92">
+        <div class="source_table" id="22a976b760c23c2556b0fd7340813852af88453d">
   <div class="header">
     <h3>app/helpers/cpus_helper.rb</h3>
     <h4>
@@ -12964,7 +13154,7 @@
 </div>
 
       
-        <div class="source_table" id="39ec99d6bacc8a73f8315c4b838fabee8c256ff1">
+        <div class="source_table" id="026497fc8aea4d2a0b5b09a37140172c048d8c6d">
   <div class="header">
     <h3>app/helpers/gpus_helper.rb</h3>
     <h4>
@@ -13035,7 +13225,7 @@
 </div>
 
       
-        <div class="source_table" id="e14ba149feb73e9bf90f61357ed677560a22df37">
+        <div class="source_table" id="f24beec8bebe3d54bdbe523c7ac2cec019f20c61">
   <div class="header">
     <h3>app/helpers/home_helper.rb</h3>
     <h4>
@@ -13106,7 +13296,7 @@
 </div>
 
       
-        <div class="source_table" id="d8042ffd5080c1ba51f3b1549e0900145692bd8e">
+        <div class="source_table" id="57acc8bbbf9d9a1b08f5ad2b29e10373472fcc04">
   <div class="header">
     <h3>app/helpers/memories_helper.rb</h3>
     <h4>
@@ -13177,7 +13367,7 @@
 </div>
 
       
-        <div class="source_table" id="94438b8a21f2eff72ace2684e9450d7ffeec423f">
+        <div class="source_table" id="4242bc602d0286e84b3557b26d96043be5910eb4">
   <div class="header">
     <h3>app/helpers/motherboards_helper.rb</h3>
     <h4>
@@ -13248,7 +13438,7 @@
 </div>
 
       
-        <div class="source_table" id="95234e3192e12b4f5ea11fc605eb5f400412140a">
+        <div class="source_table" id="ea6181b8f6965297bb947c19db0224df65b2e803">
   <div class="header">
     <h3>app/helpers/parts_helper.rb</h3>
     <h4>
@@ -13319,7 +13509,7 @@
 </div>
 
       
-        <div class="source_table" id="05b9dd5ea2b182218cbd1cbfaf8e288353eb7741">
+        <div class="source_table" id="942fda0ccaded9538645b2de8c61868ab5939d83">
   <div class="header">
     <h3>app/helpers/pc_cases_helper.rb</h3>
     <h4>
@@ -13390,7 +13580,7 @@
 </div>
 
       
-        <div class="source_table" id="7015bc60262cc29d20dd974eaf444c6728a3dea5">
+        <div class="source_table" id="a69ef049b7f2d66b725d03ad64a6b44bfa347201">
   <div class="header">
     <h3>app/helpers/psus_helper.rb</h3>
     <h4>
@@ -13461,7 +13651,7 @@
 </div>
 
       
-        <div class="source_table" id="9923167b8a093e7302fc8adc3caa3af560b8344a">
+        <div class="source_table" id="e762f031c4e0f09d90e4445749840fc1601239ad">
   <div class="header">
     <h3>app/helpers/storages_helper.rb</h3>
     <h4>
@@ -13532,7 +13722,7 @@
 </div>
 
       
-        <div class="source_table" id="583b78ecd00f459df215ca81486ba0c3b76c1f0f">
+        <div class="source_table" id="2949b2c5f0883da66aec25dab10e9542818231f4">
   <div class="header">
     <h3>app/helpers/users_helper.rb</h3>
     <h4>
@@ -13603,7 +13793,7 @@
 </div>
 
       
-        <div class="source_table" id="44667995297b00346142747090ae043e9e61f6f8">
+        <div class="source_table" id="796f40a8c28bf893f0c49d5702f7bc5cbffcee97">
   <div class="header">
     <h3>app/jobs/application_job.rb</h3>
     <h4>
@@ -13734,7 +13924,7 @@
 </div>
 
       
-        <div class="source_table" id="1aa3853dbfb027d0017bf5edbb1c414ef6d59080">
+        <div class="source_table" id="5aae5bb18a6e19a6840e2d8cd06c77b6d6494c24">
   <div class="header">
     <h3>app/lib/database_logger.rb</h3>
     <h4>
@@ -15071,7 +15261,7 @@
 </div>
 
       
-        <div class="source_table" id="765aae32b9742bd136427432800d710d2a5405e5">
+        <div class="source_table" id="5c6fc5f50b0404fe4c7b450b2443d45ec6d8d395">
   <div class="header">
     <h3>app/lib/logging_helpers.rb</h3>
     <h4>
@@ -17010,7 +17200,7 @@
 </div>
 
       
-        <div class="source_table" id="7a7645d6863108a6453ba9a9a4fda9853b82f960">
+        <div class="source_table" id="d5b771c54823b86647681e962553185e359f41db">
   <div class="header">
     <h3>app/mailers/application_mailer.rb</h3>
     <h4>
@@ -17109,7 +17299,7 @@
 </div>
 
       
-        <div class="source_table" id="e384f49354dea39fa2141748ee0a5f2da57f51f6">
+        <div class="source_table" id="f8c5bea73d2ae172d2b11cc8604dfffd74858f3b">
   <div class="header">
     <h3>app/models/application_record.rb</h3>
     <h4>
@@ -17194,7 +17384,7 @@
 </div>
 
       
-        <div class="source_table" id="5e6d6683e6883675cad3df6b8232140647eb0123">
+        <div class="source_table" id="6b83102bdb009ff7eed151af3fea774e325856d1">
   <div class="header">
     <h3>app/models/build.rb</h3>
     <h4>
@@ -17517,37 +17707,49 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="11" data-linenumber="22">
-            
-              <span class="hits">11</span>
+          <li class="never" data-hits="" data-linenumber="22">
             
 
             
               
             
 
-            <code class="ruby">    wattage = parts.sum(&amp;:wattage) || 0</code>
+            <code class="ruby">    # MODIFIED: Filter parts to only include &#39;Cpu&#39; and &#39;Gpu&#39; types before summing.</code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="11" data-linenumber="23">
+          <li class="covered" data-hits="10" data-linenumber="23">
             
-              <span class="hits">11</span>
+              <span class="hits">10</span>
             
 
             
               
             
 
-            <code class="ruby">    Rails.logger.debug &quot;[BUILD #{id}] Calculated total wattage: #{wattage}W&quot;</code>
+            <code class="ruby">    wattage = parts.where(type: [&#39;Cpu&#39;, &#39;Gpu&#39;]).sum(&amp;:wattage) || 0</code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="11" data-linenumber="24">
+          <li class="covered" data-hits="10" data-linenumber="24">
             
-              <span class="hits">11</span>
+              <span class="hits">10</span>
+            
+
+            
+              
+            
+
+            <code class="ruby">    Rails.logger.debug &quot;[BUILD #{id}] Calculated total wattage (CPU + GPU only): #{wattage}W&quot;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="10" data-linenumber="25">
+            
+              <span class="hits">10</span>
             
 
             
@@ -17559,7 +17761,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="25">
+          <li class="never" data-hits="" data-linenumber="26">
             
 
             
@@ -17571,7 +17773,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="26">
+          <li class="never" data-hits="" data-linenumber="27">
             
 
             
@@ -17579,20 +17781,6 @@
             
 
             <code class="ruby"></code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="27">
-            
-              <span class="hits">1</span>
-            
-
-            
-              
-            
-
-            <code class="ruby">  def parts_summary</code>
           </li>
         </div>
       
@@ -17606,7 +17794,7 @@
               
             
 
-            <code class="ruby">    summary = parts.group(:type).count</code>
+            <code class="ruby">  def parts_summary</code>
           </li>
         </div>
       
@@ -17620,7 +17808,7 @@
               
             
 
-            <code class="ruby">    Rails.logger.debug &quot;[BUILD #{id}] Parts summary: #{summary.inspect}&quot;</code>
+            <code class="ruby">    summary = parts.group(:type).count</code>
           </li>
         </div>
       
@@ -17634,19 +17822,21 @@
               
             
 
-            <code class="ruby">    summary</code>
+            <code class="ruby">    Rails.logger.debug &quot;[BUILD #{id}] Parts summary: #{summary.inspect}&quot;</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="31">
+          <li class="covered" data-hits="1" data-linenumber="31">
+            
+              <span class="hits">1</span>
             
 
             
               
             
 
-            <code class="ruby">  end</code>
+            <code class="ruby">    summary</code>
           </li>
         </div>
       
@@ -17658,7 +17848,7 @@
               
             
 
-            <code class="ruby"></code>
+            <code class="ruby">  end</code>
           </li>
         </div>
       
@@ -17670,12 +17860,24 @@
               
             
 
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="34">
+            
+
+            
+              
+            
+
             <code class="ruby">  # Sharing functionality</code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="34">
+          <li class="covered" data-hits="1" data-linenumber="35">
             
               <span class="hits">1</span>
             
@@ -17689,7 +17891,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="5" data-linenumber="35">
+          <li class="covered" data-hits="5" data-linenumber="36">
             
               <span class="hits">5</span>
             
@@ -17703,7 +17905,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="5" data-linenumber="36">
+          <li class="covered" data-hits="5" data-linenumber="37">
             
               <span class="hits">5</span>
             
@@ -17717,7 +17919,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="5" data-linenumber="37">
+          <li class="covered" data-hits="5" data-linenumber="38">
             
               <span class="hits">5</span>
             
@@ -17731,7 +17933,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="5" data-linenumber="38">
+          <li class="covered" data-hits="5" data-linenumber="39">
             
               <span class="hits">5</span>
             
@@ -17745,7 +17947,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="5" data-linenumber="39">
+          <li class="covered" data-hits="5" data-linenumber="40">
             
               <span class="hits">5</span>
             
@@ -17759,7 +17961,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="40">
+          <li class="never" data-hits="" data-linenumber="41">
             
 
             
@@ -17771,7 +17973,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="41">
+          <li class="never" data-hits="" data-linenumber="42">
             
 
             
@@ -17783,7 +17985,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="42">
+          <li class="covered" data-hits="1" data-linenumber="43">
             
               <span class="hits">1</span>
             
@@ -17797,7 +17999,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="43">
+          <li class="never" data-hits="" data-linenumber="44">
             
 
             
@@ -17809,7 +18011,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="3" data-linenumber="44">
+          <li class="covered" data-hits="3" data-linenumber="45">
             
               <span class="hits">3</span>
             
@@ -17823,7 +18025,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="45">
+          <li class="never" data-hits="" data-linenumber="46">
             
 
             
@@ -17835,7 +18037,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="46">
+          <li class="never" data-hits="" data-linenumber="47">
             
 
             
@@ -17847,7 +18049,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="47">
+          <li class="never" data-hits="" data-linenumber="48">
             
 
             
@@ -17859,7 +18061,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="48">
+          <li class="never" data-hits="" data-linenumber="49">
             
 
             
@@ -17871,7 +18073,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="49">
+          <li class="never" data-hits="" data-linenumber="50">
             
 
             
@@ -17883,7 +18085,7 @@
         </div>
       
         <div>
-          <li class="missed-branch" data-hits="" data-linenumber="50">
+          <li class="missed-branch" data-hits="" data-linenumber="51">
             
 
             
@@ -17903,7 +18105,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="51">
+          <li class="never" data-hits="" data-linenumber="52">
             
 
             
@@ -17915,7 +18117,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="52">
+          <li class="never" data-hits="" data-linenumber="53">
             
 
             
@@ -17927,7 +18129,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="53">
+          <li class="never" data-hits="" data-linenumber="54">
             
 
             
@@ -17939,7 +18141,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="54">
+          <li class="never" data-hits="" data-linenumber="55">
             
 
             
@@ -17947,20 +18149,6 @@
             
 
             <code class="ruby">    </code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="3" data-linenumber="55">
-            
-              <span class="hits">3</span>
-            
-
-            
-              
-            
-
-            <code class="ruby">    self.shared_data = build_data.to_json</code>
           </li>
         </div>
       
@@ -17974,24 +18162,12 @@
               
             
 
-            <code class="ruby">    generate_share_token!</code>
+            <code class="ruby">    self.shared_data = build_data.to_json</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="57">
-            
-
-            
-              
-            
-
-            <code class="ruby">    </code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="3" data-linenumber="58">
+          <li class="covered" data-hits="3" data-linenumber="57">
             
               <span class="hits">3</span>
             
@@ -18000,7 +18176,19 @@
               
             
 
-            <code class="ruby">    Rails.logger.info &quot;[BUILD #{id}] Created shareable data with #{components_data.keys.count} components&quot;</code>
+            <code class="ruby">    generate_share_token!</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="58">
+            
+
+            
+              
+            
+
+            <code class="ruby">    </code>
           </li>
         </div>
       
@@ -18014,19 +18202,21 @@
               
             
 
-            <code class="ruby">    build_data</code>
+            <code class="ruby">    Rails.logger.info &quot;[BUILD #{id}] Created shareable data with #{components_data.keys.count} components&quot;</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="60">
+          <li class="covered" data-hits="3" data-linenumber="60">
+            
+              <span class="hits">3</span>
             
 
             
               
             
 
-            <code class="ruby">  end</code>
+            <code class="ruby">    build_data</code>
           </li>
         </div>
       
@@ -18038,12 +18228,24 @@
               
             
 
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="62">
+            
+
+            
+              
+            
+
             <code class="ruby"></code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="62">
+          <li class="covered" data-hits="1" data-linenumber="63">
             
               <span class="hits">1</span>
             
@@ -18057,7 +18259,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="4" data-linenumber="63">
+          <li class="covered" data-hits="4" data-linenumber="64">
             
               <span class="hits">4</span>
             
@@ -18071,7 +18273,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="64">
+          <li class="never" data-hits="" data-linenumber="65">
             
 
             
@@ -18083,7 +18285,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="65">
+          <li class="never" data-hits="" data-linenumber="66">
             
 
             
@@ -18095,7 +18297,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="66">
+          <li class="covered" data-hits="1" data-linenumber="67">
             
               <span class="hits">1</span>
             
@@ -18109,7 +18311,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="2" data-linenumber="67">
+          <li class="covered" data-hits="2" data-linenumber="68">
             
               <span class="hits">2</span>
             
@@ -18131,7 +18333,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="68">
+          <li class="covered" data-hits="1" data-linenumber="69">
             
               <span class="hits">1</span>
             
@@ -18145,7 +18347,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="69">
+          <li class="never" data-hits="" data-linenumber="70">
             
 
             
@@ -18157,7 +18359,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="70">
+          <li class="never" data-hits="" data-linenumber="71">
             
 
             
@@ -18169,7 +18371,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="71">
+          <li class="covered" data-hits="1" data-linenumber="72">
             
               <span class="hits">1</span>
             
@@ -18183,7 +18385,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="3" data-linenumber="72">
+          <li class="covered" data-hits="3" data-linenumber="73">
             
               <span class="hits">3</span>
             
@@ -18205,7 +18407,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="2" data-linenumber="73">
+          <li class="covered" data-hits="2" data-linenumber="74">
             
               <span class="hits">2</span>
             
@@ -18219,7 +18421,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="74">
+          <li class="never" data-hits="" data-linenumber="75">
             
 
             
@@ -18227,20 +18429,6 @@
             
 
             <code class="ruby">  rescue JSON::ParserError =&gt; e</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="75">
-            
-              <span class="hits">1</span>
-            
-
-            
-              
-            
-
-            <code class="ruby">    Rails.logger.error &quot;[BUILD #{id}] Failed to parse shared data: #{e.message}&quot;</code>
           </li>
         </div>
       
@@ -18254,19 +18442,21 @@
               
             
 
-            <code class="ruby">    {}</code>
+            <code class="ruby">    Rails.logger.error &quot;[BUILD #{id}] Failed to parse shared data: #{e.message}&quot;</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="77">
+          <li class="covered" data-hits="1" data-linenumber="77">
+            
+              <span class="hits">1</span>
             
 
             
               
             
 
-            <code class="ruby">  end</code>
+            <code class="ruby">    {}</code>
           </li>
         </div>
       
@@ -18278,12 +18468,24 @@
               
             
 
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="79">
+            
+
+            
+              
+            
+
             <code class="ruby"></code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="79">
+          <li class="covered" data-hits="1" data-linenumber="80">
             
               <span class="hits">1</span>
             
@@ -18297,7 +18499,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="80">
+          <li class="never" data-hits="" data-linenumber="81">
             
 
             
@@ -18309,7 +18511,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="81">
+          <li class="covered" data-hits="1" data-linenumber="82">
             
               <span class="hits">1</span>
             
@@ -18323,9 +18525,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="125" data-linenumber="82">
+          <li class="covered" data-hits="124" data-linenumber="83">
             
-              <span class="hits">125</span>
+              <span class="hits">124</span>
             
 
             
@@ -18337,7 +18539,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="83">
+          <li class="never" data-hits="" data-linenumber="84">
             
 
             
@@ -18349,7 +18551,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="84">
+          <li class="never" data-hits="" data-linenumber="85">
             
 
             
@@ -18361,7 +18563,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="85">
+          <li class="covered" data-hits="1" data-linenumber="86">
             
               <span class="hits">1</span>
             
@@ -18375,9 +18577,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="125" data-linenumber="86">
+          <li class="covered" data-hits="124" data-linenumber="87">
             
-              <span class="hits">125</span>
+              <span class="hits">124</span>
             
 
             
@@ -18389,7 +18591,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="87">
+          <li class="never" data-hits="" data-linenumber="88">
             
 
             
@@ -18401,7 +18603,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="88">
+          <li class="never" data-hits="" data-linenumber="89">
             
 
             
@@ -18413,7 +18615,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="89">
+          <li class="covered" data-hits="1" data-linenumber="90">
             
               <span class="hits">1</span>
             
@@ -18427,7 +18629,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="4" data-linenumber="90">
+          <li class="covered" data-hits="4" data-linenumber="91">
             
               <span class="hits">4</span>
             
@@ -18441,7 +18643,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="91">
+          <li class="never" data-hits="" data-linenumber="92">
             
 
             
@@ -18453,7 +18655,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="92">
+          <li class="never" data-hits="" data-linenumber="93">
             
 
             
@@ -18465,7 +18667,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="93">
+          <li class="covered" data-hits="1" data-linenumber="94">
             
               <span class="hits">1</span>
             
@@ -18479,9 +18681,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="146" data-linenumber="94">
+          <li class="covered" data-hits="144" data-linenumber="95">
             
-              <span class="hits">146</span>
+              <span class="hits">144</span>
             
 
             
@@ -18497,7 +18699,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="6" data-linenumber="95">
+          <li class="covered" data-hits="6" data-linenumber="96">
             
               <span class="hits">6</span>
             
@@ -18511,13 +18713,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="96">
+          <li class="never" data-hits="" data-linenumber="97">
             
 
             
               
-                <span class="hits" title="else branch hit 140 times">
-                  else: 140
+                <span class="hits" title="else branch hit 138 times">
+                  else: 138
                 </span>
               
             
@@ -18527,9 +18729,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="140" data-linenumber="97">
+          <li class="covered" data-hits="138" data-linenumber="98">
             
-              <span class="hits">140</span>
+              <span class="hits">138</span>
             
 
             
@@ -18541,7 +18743,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="98">
+          <li class="never" data-hits="" data-linenumber="99">
             
 
             
@@ -18553,7 +18755,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="99">
+          <li class="never" data-hits="" data-linenumber="100">
             
 
             
@@ -18565,7 +18767,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="100">
+          <li class="never" data-hits="" data-linenumber="101">
             
 
             
@@ -18577,7 +18779,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="101">
+          <li class="covered" data-hits="1" data-linenumber="102">
             
               <span class="hits">1</span>
             
@@ -18591,15 +18793,15 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="12" data-linenumber="102">
+          <li class="covered" data-hits="11" data-linenumber="103">
             
-              <span class="hits">12</span>
+              <span class="hits">11</span>
             
 
             
               
-                <span class="hits" title="then branch hit 11 times">
-                  then: 11
+                <span class="hits" title="then branch hit 10 times">
+                  then: 10
                 </span>
               
                 <span class="hits" title="else branch hit 1 times">
@@ -18613,9 +18815,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="11" data-linenumber="103">
+          <li class="covered" data-hits="10" data-linenumber="104">
             
-              <span class="hits">11</span>
+              <span class="hits">10</span>
             
 
             
@@ -18627,7 +18829,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="104">
+          <li class="never" data-hits="" data-linenumber="105">
             
 
             
@@ -18639,7 +18841,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="105">
+          <li class="never" data-hits="" data-linenumber="106">
             
 
             
@@ -18651,7 +18853,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="106">
+          <li class="never" data-hits="" data-linenumber="107">
             
 
             
@@ -18667,7 +18869,7 @@
 </div>
 
       
-        <div class="source_table" id="a6ea01ffcc22b871034feba95b40891bccd98607">
+        <div class="source_table" id="d59bb4c0d707b5ed9b277cd4d0c561e1f0b8c8a6">
   <div class="header">
     <h3>app/models/build_item.rb</h3>
     <h4>
@@ -19070,23 +19272,23 @@
         </div>
       
         <div>
-          <li class="missed-branch" data-hits="69" data-linenumber="28">
+          <li class="missed-branch" data-hits="68" data-linenumber="28">
             
-              <span class="hits">69</span>
+              <span class="hits">68</span>
             
 
             
               
-                <span class="hits" title="then branch hit 69 times">
-                  then: 69
+                <span class="hits" title="then branch hit 68 times">
+                  then: 68
                 </span>
               
                 <span class="hits" title="else branch hit 0 times">
                   else: 0
                 </span>
               
-                <span class="hits" title="then branch hit 69 times">
-                  then: 69
+                <span class="hits" title="then branch hit 68 times">
+                  then: 68
                 </span>
               
                 <span class="hits" title="else branch hit 0 times">
@@ -19138,9 +19340,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="69" data-linenumber="32">
+          <li class="covered" data-hits="68" data-linenumber="32">
             
-              <span class="hits">69</span>
+              <span class="hits">68</span>
             
 
             
@@ -19242,9 +19444,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="83" data-linenumber="40">
+          <li class="covered" data-hits="82" data-linenumber="40">
             
-              <span class="hits">83</span>
+              <span class="hits">82</span>
             
 
             
@@ -19279,8 +19481,8 @@
 
             
               
-                <span class="hits" title="else branch hit 77 times">
-                  else: 77
+                <span class="hits" title="else branch hit 76 times">
+                  else: 76
                 </span>
               
             
@@ -19290,9 +19492,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="77" data-linenumber="43">
+          <li class="covered" data-hits="76" data-linenumber="43">
             
-              <span class="hits">77</span>
+              <span class="hits">76</span>
             
 
             
@@ -19430,7 +19632,7 @@
 </div>
 
       
-        <div class="source_table" id="fd561b56139273ce7d169e4c35e2ee32271757d9">
+        <div class="source_table" id="4cbf548a4698b4512e67d7a9d4c757598aa486bd">
   <div class="header">
     <h3>app/models/cooler.rb</h3>
     <h4>
@@ -19501,7 +19703,7 @@
 </div>
 
       
-        <div class="source_table" id="8e601589d06da1335572bcc028065843ef8c1f8b">
+        <div class="source_table" id="8b3ba20ea8c12d9b828f610391b939d01b35cb24">
   <div class="header">
     <h3>app/models/cpu.rb</h3>
     <h4>
@@ -19764,9 +19966,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="144" data-linenumber="18">
+          <li class="covered" data-hits="143" data-linenumber="18">
             
-              <span class="hits">144</span>
+              <span class="hits">143</span>
             
 
             
@@ -19801,8 +20003,8 @@
 
             
               
-                <span class="hits" title="else branch hit 136 times">
-                  else: 136
+                <span class="hits" title="else branch hit 135 times">
+                  else: 135
                 </span>
               
             
@@ -19812,9 +20014,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="136" data-linenumber="21">
+          <li class="covered" data-hits="135" data-linenumber="21">
             
-              <span class="hits">136</span>
+              <span class="hits">135</span>
             
 
             
@@ -19826,15 +20028,15 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="136" data-linenumber="22">
+          <li class="covered" data-hits="135" data-linenumber="22">
             
-              <span class="hits">136</span>
+              <span class="hits">135</span>
             
 
             
               
-                <span class="hits" title="then branch hit 64 times">
-                  then: 64
+                <span class="hits" title="then branch hit 63 times">
+                  then: 63
                 </span>
               
                 <span class="hits" title="else branch hit 72 times">
@@ -19888,7 +20090,7 @@
 </div>
 
       
-        <div class="source_table" id="11689a41889722db21550a5bb933f7719ac3c508">
+        <div class="source_table" id="c1d6ee4dfd0d6d0d7db987a14e0c161b55bf242b">
   <div class="header">
     <h3>app/models/gpu.rb</h3>
     <h4>
@@ -19959,7 +20161,7 @@
 </div>
 
       
-        <div class="source_table" id="be91a57a65867a529dbac40fb97d190ec01d7199">
+        <div class="source_table" id="033632b9d0cb3022330019d67bbd728ff5e4891a">
   <div class="header">
     <h3>app/models/memory.rb</h3>
     <h4>
@@ -20030,7 +20232,7 @@
 </div>
 
       
-        <div class="source_table" id="7df4e3637487f910ebad4a0ddbe8ebea4790923b">
+        <div class="source_table" id="030399f4d2b4becd3cd169d8119cf41eddab3185">
   <div class="header">
     <h3>app/models/motherboard.rb</h3>
     <h4>
@@ -20101,7 +20303,7 @@
 </div>
 
       
-        <div class="source_table" id="233062ed4f8b817c5593388fb130e9091b540063">
+        <div class="source_table" id="501421c4718ae347e1d6d75f5d629bdb3d7e3695">
   <div class="header">
     <h3>app/models/part.rb</h3>
     <h4>
@@ -20556,15 +20758,15 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="333" data-linenumber="31">
+          <li class="covered" data-hits="332" data-linenumber="31">
             
-              <span class="hits">333</span>
+              <span class="hits">332</span>
             
 
             
               
-                <span class="hits" title="else branch hit 329 times">
-                  else: 329
+                <span class="hits" title="else branch hit 328 times">
+                  else: 328
                 </span>
               
                 <span class="hits" title="then branch hit 4 times">
@@ -20578,9 +20780,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="329" data-linenumber="32">
+          <li class="covered" data-hits="328" data-linenumber="32">
             
-              <span class="hits">329</span>
+              <span class="hits">328</span>
             
 
             
@@ -20592,9 +20794,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="329" data-linenumber="33">
+          <li class="covered" data-hits="328" data-linenumber="33">
             
-              <span class="hits">329</span>
+              <span class="hits">328</span>
             
 
             
@@ -20606,9 +20808,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="329" data-linenumber="34">
+          <li class="covered" data-hits="328" data-linenumber="34">
             
-              <span class="hits">329</span>
+              <span class="hits">328</span>
             
 
             
@@ -20752,9 +20954,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="329" data-linenumber="45">
+          <li class="covered" data-hits="328" data-linenumber="45">
             
-              <span class="hits">329</span>
+              <span class="hits">328</span>
             
 
             
@@ -20792,9 +20994,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="329" data-linenumber="48">
+          <li class="covered" data-hits="328" data-linenumber="48">
             
-              <span class="hits">329</span>
+              <span class="hits">328</span>
             
 
             
@@ -20872,9 +21074,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="350" data-linenumber="54">
+          <li class="covered" data-hits="349" data-linenumber="54">
             
-              <span class="hits">350</span>
+              <span class="hits">349</span>
             
 
             
@@ -20909,8 +21111,8 @@
 
             
               
-                <span class="hits" title="else branch hit 335 times">
-                  else: 335
+                <span class="hits" title="else branch hit 334 times">
+                  else: 334
                 </span>
               
             
@@ -20920,9 +21122,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="335" data-linenumber="57">
+          <li class="covered" data-hits="334" data-linenumber="57">
             
-              <span class="hits">335</span>
+              <span class="hits">334</span>
             
 
             
@@ -21022,7 +21224,7 @@
 </div>
 
       
-        <div class="source_table" id="7ec65b88696dad5c0c6973f2ecfc953341ed4e9d">
+        <div class="source_table" id="3d161f24e9aa63ff1b594bc23caf624078ebcc6b">
   <div class="header">
     <h3>app/models/pc_case.rb</h3>
     <h4>
@@ -21131,7 +21333,7 @@
 </div>
 
       
-        <div class="source_table" id="ca59c035338f6991311d2887b2a63b97ce9732c4">
+        <div class="source_table" id="ba70f1581be9eddaee6df72d46819d0dfdcd8189">
   <div class="header">
     <h3>app/models/psu.rb</h3>
     <h4>
@@ -21202,7 +21404,7 @@
 </div>
 
       
-        <div class="source_table" id="d85467a8d9417185fedcd413fb3a6e3badefaf7b">
+        <div class="source_table" id="b1aa564c85e01780ee6a26873d90b75e17e1e348">
   <div class="header">
     <h3>app/models/storage.rb</h3>
     <h4>
@@ -21273,7 +21475,7 @@
 </div>
 
       
-        <div class="source_table" id="a46f1cdb109e44f3f545ec434d2d5033c676d168">
+        <div class="source_table" id="9cf8fba569c21d036033814a406009d53184f04f">
   <div class="header">
     <h3>app/models/user.rb</h3>
     <h4>
@@ -21500,9 +21702,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="144" data-linenumber="15">
+          <li class="covered" data-hits="143" data-linenumber="15">
             
-              <span class="hits">144</span>
+              <span class="hits">143</span>
             
 
             
@@ -21864,9 +22066,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="143" data-linenumber="43">
+          <li class="covered" data-hits="142" data-linenumber="43">
             
-              <span class="hits">143</span>
+              <span class="hits">142</span>
             
 
             
@@ -21878,9 +22080,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="143" data-linenumber="44">
+          <li class="covered" data-hits="142" data-linenumber="44">
             
-              <span class="hits">143</span>
+              <span class="hits">142</span>
             
 
             
@@ -21892,9 +22094,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="143" data-linenumber="45">
+          <li class="covered" data-hits="142" data-linenumber="45">
             
-              <span class="hits">143</span>
+              <span class="hits">142</span>
             
 
             
@@ -21903,8 +22105,8 @@
                   then: 2
                 </span>
               
-                <span class="hits" title="else branch hit 141 times">
-                  else: 141
+                <span class="hits" title="else branch hit 140 times">
+                  else: 140
                 </span>
               
             
@@ -21952,9 +22154,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="131" data-linenumber="49">
+          <li class="covered" data-hits="130" data-linenumber="49">
             
-              <span class="hits">131</span>
+              <span class="hits">130</span>
             
 
             
@@ -22004,9 +22206,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="131" data-linenumber="53">
+          <li class="covered" data-hits="130" data-linenumber="53">
             
-              <span class="hits">131</span>
+              <span class="hits">130</span>
             
 
             
@@ -22108,9 +22310,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="143" data-linenumber="61">
+          <li class="covered" data-hits="142" data-linenumber="61">
             
-              <span class="hits">143</span>
+              <span class="hits">142</span>
             
 
             
@@ -22145,8 +22347,8 @@
 
             
               
-                <span class="hits" title="else branch hit 133 times">
-                  else: 133
+                <span class="hits" title="else branch hit 132 times">
+                  else: 132
                 </span>
               
             
@@ -22156,9 +22358,9 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="133" data-linenumber="64">
+          <li class="covered" data-hits="132" data-linenumber="64">
             
-              <span class="hits">133</span>
+              <span class="hits">132</span>
             
 
             


### PR DESCRIPTION
### Summary

This PR updates the `total_wattage` calculation logic in the `Build` model. The method now correctly sums the wattage of **only** the CPU and GPU components, providing a more accurate power consumption estimate for PSU selection.

### Changes

* **`app/models/build.rb`**:
    * Modified the `total_wattage` method to filter for parts of type `Cpu` and `Gpu` before summing their `wattage` attributes.

* **`spec/models/build_spec.rb`**:
    * Updated the corresponding test case for `total_wattage`. The test now includes a non-CPU/GPU part (a Motherboard with wattage) in the build and asserts that its wattage is correctly **ignored** in the final calculation. The test for `total_cost` was also updated to reflect the presence of the new part.

### Important Note on Branching

This branch was created from `main` **before** the changes in branch `#43` (functional remove/change buttons and RSpec fixes) were merged. After this PR is approved, a **rebase or merge** from `main` will be required to incorporate the test fixes from `#43` before this branch can be merged into `main`.